### PR TITLE
underline indicator missing needed contrast

### DIFF
--- a/apps/enji.dev/src/styles/components.css
+++ b/apps/enji.dev/src/styles/components.css
@@ -130,8 +130,8 @@
     @apply dark:bg-slate-800;
 
     &__indicator {
-      @apply absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-slate-300;
-      @apply dark:bg-slate-600;
+      @apply absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-accent-600;
+      @apply dark:bg-accent-600;
     }
   }
 

--- a/apps/enji.dev/src/styles/components.css
+++ b/apps/enji.dev/src/styles/components.css
@@ -130,8 +130,8 @@
     @apply dark:bg-slate-800;
 
     &__indicator {
-      @apply absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-accent-600;
-      @apply dark:bg-accent-600;
+      @apply absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-accent-400;
+      @apply dark:bg-accent-800;
     }
   }
 


### PR DESCRIPTION
# 

First of all. 

### **WOW.** 

When I found your resume (on Figma Community), I was not prepared to stumble upon the cleanest personal portfolio on whole the internet. Your usage of motion, color, vector graphics, page transitions, in-page navigation, and overall monorepo architecture is a piece of art that truly speaks for itself. I can hardly believe you would be willing to share this quality of composition for free.

It took quite a lot of browsing and picking apart to find some aspect that I could possibly improve upon, and I think this suggestion boils down to a matter of personal taste. Feel free to disregard.

===

As I was initially putting together the information architecture of your site, I recall visiting your [Skills & Tools](https://www.enji.dev/work/skills-and-tools) page and failing to notice the underline indicator signifying your level of expertise. Though the size and positioning are appropriate, I found that the missing color contrast made it difficult to visually distinguish the indicators vs borders as well as the variability in expertise between badges. Among the available colors, I found that an alternative color scheme based on a darker shade of 'accent' captured more visual attention while keeping a sense of color consistency with the rest of the UI.

Compare the original scheme:

![Screenshot_1-6-2024_201515_www enji dev](https://github.com/enjidev/enji.dev/assets/55509500/4c3553ca-7bec-47c3-a8dd-282d313c3441)

with my suggested color scheme:

![Screenshot_1-6-2024_191525_localhost](https://github.com/enjidev/enji.dev/assets/55509500/cb1e3bf0-822b-4b93-b59b-ed0d53da2513)

Both choices have tradeoffs, so again, feel free to disregard. 

Let me know what you think! 